### PR TITLE
Fix type parsing for capture/wildcard types.

### DIFF
--- a/src/main/java/org/zwobble/couscous/frontends/java/JavaTypes.java
+++ b/src/main/java/org/zwobble/couscous/frontends/java/JavaTypes.java
@@ -42,9 +42,14 @@ public class JavaTypes {
         if (typeBinding.isArray()) {
             return Types.array(typeOf(typeBinding.getElementType()));
         }
+
+        if (typeBinding.isCapture()) {
+            typeBinding = typeBinding.getErasure();
+        }
+
         ITypeBinding outerClass = typeBinding.getDeclaringClass();
         if (outerClass == null) outerClass = typeBinding.getErasure().getDeclaringClass();
-        
+
         if (typeBinding.isTypeVariable()) {
             Identifier declaringScope = getDeclaringScope(typeBinding);
             return new TypeParameter(declaringScope, typeBinding.getName());


### PR DESCRIPTION
This PR aims to fix two errors in type parsing.
All changes target the method: `JavaTypes.typeOf(ITypeBinding typeBinding)`


commit: [feat: fix inner->inner types in Anonymous base type](https://github.com/mwilliamson/java-couscous/commit/ae940fb19dab65cb760b87d9a30fb392e279035a)
Example code to show the changed behavior:
```csharp
// before the fix: `Stream<Numbering.AbstractNumLevel>` the AbstractNumLevel nested class name is invalid.
namespace Mammoth.Couscous.org.zwobble.mammoth.@internal.docx {
    internal class Numbering__Anonymous_0 : Function<Numbering__AbstractNum, Stream<Numbering.AbstractNumLevel>> {
        public Stream<Numbering.AbstractNumLevel> apply(Numbering__AbstractNum abstractNum) {
            return ((abstractNum._levels).values()).stream();
        }
    }
}

// after the fix: `Stream<Numbering__AbstractNumLevel>` the nested class name is now valid.
namespace Mammoth.Couscous.org.zwobble.mammoth.@internal.docx {
    internal class Numbering__Anonymous_0 : Function<Numbering__AbstractNum, Stream<Numbering__AbstractNumLevel>> {
        public Stream<Numbering__AbstractNumLevel> apply(Numbering__AbstractNum abstractNum) {
            return ((abstractNum._levels).values()).stream();
        }
    }
}
```

commit: [feat: fix handling of capture types](https://github.com/mwilliamson/java-couscous/commit/37ddfbd10aed1e5a884f4ec6179254bb4e38259b)
Example code to show the changed behavior:
```csharp
// before the fix: The type `StatefulBodyXmlReader__XmlNode` is invalid bacause `readElements` is defined as: `ReadResult readElements(Iterable<? extends XmlNode> nodes)`
// The type `? extends XmlNode` gets misinterpreted when filling `lazyFilter<T, R>` T type parameter.
namespace Mammoth.Couscous.org.zwobble.mammoth.@internal.docx {
    internal class StatefulBodyXmlReader {
        ...

        public ReadResult readElements(Iterable<XmlNode> nodes) {
            return ReadResult.flatMap<XmlElement>(lazyFilter<StatefulBodyXmlReader__XmlNode, XmlElement>(nodes, typeof(XmlElement)), new StatefulBodyXmlReader__Anonymous_6(this));
        }

        ...
    }
}

// after the fix: The `lazyFilter<T, R>` T type parameter is correct.
namespace Mammoth.Couscous.org.zwobble.mammoth.@internal.docx {
    internal class StatefulBodyXmlReader {
        ...

        public ReadResult readElements(Iterable<XmlNode> nodes) {
            return ReadResult.flatMap<XmlElement>(lazyFilter<XmlNode, XmlElement>(nodes, typeof(XmlElement)), new StatefulBodyXmlReader__Anonymous_6(this));
        }

        ...
    }
}
```

Feel free to close this pull request if it does not meet your requirements.