### PR TITLE
feat: simplify closure this parameter field name

### DIFF
--- a/src/main/java/org/zwobble/couscous/transforms/ClosureGenerator.java
+++ b/src/main/java/org/zwobble/couscous/transforms/ClosureGenerator.java
@@ -119,7 +119,8 @@ public class ClosureGenerator {
             @Override
             public FieldDeclarationNode visit(ThisReferenceNode thisReference) {
                 Type type = thisReference.getType();
-                String name = "this_" + erasure(type).getQualifiedName().replace(".", "__");
+                String name = String.join("__", erasure(type).getTypeNames()).replace(".", "__");
+                name = name.substring(0, 1).toLowerCase() + name.substring(1);
                 return field(name, type);
             }
         });


### PR DESCRIPTION
This PR simplifies the `this` parameter field name in generated closure classes making it easier readable.

Feel free to close this pull request if it does not meet your requirements.

```csharp
// before the change: `internal StatefulBodyXmlReader _this_org__zwobble__mammoth__internal__docx__StatefulBodyXmlReader;`
namespace Mammoth.Couscous.org.zwobble.mammoth.@internal.docx {
    internal class StatefulBodyXmlReader__Anonymous_6 : Mammoth.Couscous.java.util.function.Function<XmlElement, ReadResult> {
        internal StatefulBodyXmlReader _this_org__zwobble__mammoth__internal__docx__StatefulBodyXmlReader;
        internal StatefulBodyXmlReader__Anonymous_6(StatefulBodyXmlReader this_org__zwobble__mammoth__internal__docx__StatefulBodyXmlReader) {
            this._this_org__zwobble__mammoth__internal__docx__StatefulBodyXmlReader = this_org__zwobble__mammoth__internal__docx__StatefulBodyXmlReader;
        }
        public ReadResult apply(XmlElement arg0) {
            return (this._this_org__zwobble__mammoth__internal__docx__StatefulBodyXmlReader).readElement(arg0);
        }
    }
}

// after the change: `internal StatefulBodyXmlReader _statefulBodyXmlReader;`
namespace Mammoth.Couscous.org.zwobble.mammoth.@internal.docx {
    internal class StatefulBodyXmlReader__Anonymous_6 : Function<XmlElement, ReadResult> {
        internal StatefulBodyXmlReader _statefulBodyXmlReader;
        internal StatefulBodyXmlReader__Anonymous_6(StatefulBodyXmlReader statefulBodyXmlReader) {
            this._statefulBodyXmlReader = statefulBodyXmlReader;
        }
        public ReadResult apply(XmlElement arg0) {
            return (this._statefulBodyXmlReader).readElement(arg0);
        }
    }
}
```